### PR TITLE
Fix Gatekeeper marker rendering and adjust drift car simulation constraints

### DIFF
--- a/examples/drift_car/test_drift.py
+++ b/examples/drift_car/test_drift.py
@@ -51,7 +51,6 @@ import matplotlib.pyplot as plt
 from dataclasses import dataclass
 from typing import Optional, Tuple, Dict, Any, Union
 import re
-
 from safe_control.envs.drifting_env import DriftingEnv
 from safe_control.robots.drifting_car import DriftingCar, DriftingCarSimulator
 from safe_control.position_control.mpcc import MPCC
@@ -153,7 +152,7 @@ class SimulationConfig:
     nominal_horizon_time: float = 6.0    # MPCC prediction horizon [s]
     backup_horizon_time: float = 3.0     # Backup trajectory horizon [s]
     event_offset: float = 0.05           # Gatekeeper re-evaluation interval [s]
-    safety_margin: float = 1.25          # Collision checking margin [m]
+    safety_margin: float = 1.00          # Collision checking margin [m]
     initial_velocity: float = 10.0        # Starting velocity [m/s]
     target_velocity: float = 10.0         # Target velocity [m/s]
 
@@ -234,7 +233,7 @@ def setup_vehicle(config: TestConfig, env: DriftingEnv, ax: plt.Axes) -> Tuple[D
     
     # Initial state in ego lane
     X0 = np.array([
-        5.0,                        # x
+        1.0,                        # x (changed from 5.0)
         ego_lane_y,                 # y
         np.deg2rad(0),              # theta
         0, 0,                       # r, beta

--- a/examples/drift_car/test_drift.py
+++ b/examples/drift_car/test_drift.py
@@ -152,7 +152,7 @@ class SimulationConfig:
     nominal_horizon_time: float = 6.0    # MPCC prediction horizon [s]
     backup_horizon_time: float = 3.0     # Backup trajectory horizon [s]
     event_offset: float = 0.05           # Gatekeeper re-evaluation interval [s]
-    safety_margin: float = 1.00          # Collision checking margin [m]
+    safety_margin: float = 0.01          # Collision checking margin [m]
     initial_velocity: float = 10.0        # Starting velocity [m/s]
     target_velocity: float = 10.0         # Target velocity [m/s]
 
@@ -233,7 +233,7 @@ def setup_vehicle(config: TestConfig, env: DriftingEnv, ax: plt.Axes) -> Tuple[D
     
     # Initial state in ego lane
     X0 = np.array([
-        1.0,                        # x (changed from 5.0)
+        1.0,                        # x
         ego_lane_y,                 # y
         np.deg2rad(0),              # theta
         0, 0,                       # r, beta

--- a/shielding/gatekeeper.py
+++ b/shielding/gatekeeper.py
@@ -709,7 +709,12 @@ class Gatekeeper:
             switch_idx = self.actual_nominal_steps  # Index of switching state
             if 0 <= switch_idx < len(self.committed_x_traj):
                 switch_state = self.committed_x_traj[switch_idx]
-                self.switching_point_marker.set_data([switch_state[0]], [switch_state[1]])
+                switch_x=switch_state[0]
+                if switch_x> self.ax.get_xlim()[1]:
+                    switch_x=self.ax.get_xlim()[1]
+                    self.switching_point_marker.set_data([switch_x], [switch_state[1]])
+                else:
+                    self.switching_point_marker.set_data([switch_state[0]], [switch_state[1]])
             else:
                 self.switching_point_marker.set_data([], [])
     


### PR DESCRIPTION
Key Changes:

Gatekeeper Renderer: Capped the switching marker's x-coordinate to the axis limit in gatekeeper.py to prevent off-screen rendering.
Simulation Constraints: Decreased the collision safety_margin to 0.01 and shifted the ego car's starting position back to x=1.0 in test_drift.py 